### PR TITLE
Preventing Buffer Overflows using scanf

### DIFF
--- a/Client/View/Account_UI.c
+++ b/Client/View/Account_UI.c
@@ -13,7 +13,7 @@ int Account_UI_SignIn(){
     char name[30] , password[30];
     int sex;
     printf("请输入要注册的用户名:");
-    scanf("%s",name);
+    scanf("%30s",name);
     ffflush();
     while(1){
         printf("请输入性别(男/女):");

--- a/Client/View/Account_UI.c
+++ b/Client/View/Account_UI.c
@@ -17,7 +17,7 @@ int Account_UI_SignIn(){
     ffflush();
     while(1){
         printf("请输入性别(男/女):");
-        scanf("%s",password);//懒得再开数组,暂借一下
+        scanf("%30s",password);//懒得再开数组,暂借一下
         ffflush();
         if(strcmp(password ,"男") == 0){
             sex = 1;

--- a/Client/View/Chat_UI.c
+++ b/Client/View/Chat_UI.c
@@ -27,7 +27,7 @@ void Chat_UI_Private(){
     friends_t * f;
     while(1){
         printf("请输入好友用户名:");
-        scanf("%s",fname);
+        scanf("%30s",fname);
         ffflush();
         List_ForEach(FriendsList ,f){
             //printf("f->name = %s\n" ,f->name);

--- a/Client/View/Friends_UI.c
+++ b/Client/View/Friends_UI.c
@@ -56,7 +56,7 @@ void Friends_UI_ShowApply(){
 void Friends_UI_Add(){
     char fname[30];
     printf("请输入待添加的好友名:");
-    scanf("%s",fname);
+    scanf("%30s",fname);
     ffflush();
     friends_t *f;
     List_ForEach(FriendsList ,f){

--- a/Client/View/Group_UI.c
+++ b/Client/View/Group_UI.c
@@ -37,7 +37,7 @@ void Group_UI_ShowList(){
 void Group_UI_AddMember(int gid){
     char name[30]; 
     printf("请输入要邀请的好友名称:");
-    scanf("%s",name);
+    scanf("%30s",name);
     ffflush();
     friends_t *f;
     List_ForEach(FriendsList ,f){


### PR DESCRIPTION
If the client received input username or password > 30 chars, the input got written beyond the allocated space, which caused a buffer overflow -> Client crashed. For strings much longer than 30 chars (>60 chars) it was possible to let the server application crash, too. The problem got solved by changing the scanf methods, which are used for receiving input.